### PR TITLE
Bump laravel-doctrine/orm and laravel/framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     }
   },
   "require": {
-    "laravel-doctrine/orm": "~1.8",
-    "laravel/framework": "^9.19",
+    "laravel-doctrine/orm": "^1.8|^2.0",
+    "laravel/framework": "^9.19|^10.10",
     "doctrine/data-fixtures": "^1.6"
   },
   "extra": {


### PR DESCRIPTION
This PR adds an extra constraint to `laravel-doctrine/orm` and `laravel/framework` to allow for the latest updates of each.
I don't have time to add tests into this package just yet...